### PR TITLE
Flight Updates

### DIFF
--- a/src/RumDaDuMCPE/HUDTask.php
+++ b/src/RumDaDuMCPE/HUDTask.php
@@ -3,12 +3,18 @@
 namespace RumDaDuMCPE;
 
 use pocketmine\scheduler\Task;
+use pocketmine\utils\TextFormat;
 
 class HUDTask extends Task {
 	public function onRun (int $currentTick) {
 		$plugin = CombatHUD::getInstance();
 		foreach ($plugin->getServer()->getOnlinePlayers() as $player) {
 			if ($plugin->PlayerisInCombat($player)) {
+				if($player->getAllowFlight() && !$player->isCreative()){
+					$player->setAllowFlight(false);
+					$player->setFlying(false);
+					$player->sendMessage(TextFormat::colorize("&cYou cannot fly whilst in combat. Disabled your flight."));
+				}
 				$player->sendPopup($plugin->sendHUD($player));
 			} else {
 				return;


### PR DESCRIPTION
Hey, so this pull request offers a new feature available, which is called “Disabling flight whilst still in combat”.

## What does this Pull Request do?
This is essentially a check for servers to stop others abusing /fly and bypassing the system.
Since this could be abused as seen before on my server. So this system essentially patches up abuses for other players abusing /fly whilst in combat.
Once they type /fly, the task will check to ensure they’re in flight mode or not in creative mode before setting their flight settings to false. This hasn’t been tested to work yet, but as far as checks go, this should work like a flow.

## Why is this useful?
This check is useful for those that have badd configurations, and have no clue how to use them. I’m referring to the combatlogger’s config. This can also be useful for any safety checks before successfully enabling their flight without being in combat. Let’s just say this is a safety check just in case if anyone can “somehow” abuse it. Since with this method, I can guarantee there will be no bypasses to it. 

## Is there any other bypasses we should know about?
The only way of “bypassing” this system is by going into creative mode. Soon, I plan to remove the creative check and implement a way so for example, The difference between the isCreative() function and the plugin’s check, is with the plugin’s check, it could check whether or not the player was in creative before the “combat” staged took place. If they were, it’ll perform a setCreáiveModeCheck[] true or false. If true, it’ll take them out of creative mode if they typed /gmc after the “combat task” took place. If false, then the combat task won’t work.
Or possibly implement a function to this. Again, I’m not sure how this will work yet.


## Any other notes?
For now, you can merge this PR if possible whilst I start to reimplement the other features I stated, but again, it’s your choice.
Thank you.