### PR TITLE
CombatTimer 2.0.0

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: CombatHUD
 author: RumDaDuMCPE
 main: RumDaDuMCPE\CombatHUD
-api: [3.0.0, 3.0.0-ALPHA5, 3.0.0-ALPHA6, 3.0.0-ALPHA7]
-version: "1.0"
+api: 3.0.0
+version: 2.0.0

--- a/src/RumDaDuMCPE/CombatHUD.php
+++ b/src/RumDaDuMCPE/CombatHUD.php
@@ -4,7 +4,7 @@ namespace RumDaDuMCPE;
 use pocketmine\plugin\PluginBase;
 use pocketmine\event\Listener;
 use pocketmine\Player;
-use pocketmine\event\player\PlayerJoinEvent;
+use pocketmine\event\player\PlayerLoginEvent;
 
 class CombatHUD extends PluginBase implements Listener {
 
@@ -21,9 +21,9 @@ class CombatHUD extends PluginBase implements Listener {
 	public static function getInstance() {
 		return self::$instance;
 	}
-	public function onJoin(PlayerJoinEvent $event){
+	public function onJoin(PlayerLoginEvent $event){
 $player = $event->getPlayer();
-		$this->setCreativeCheck(false); //ensures creative checks are false to prevent errors when it isn't recognized.
+		$this->setCreativeCheck($player, false); //ensures creative checks are false to prevent errors when it isn't recognized.
 	}
 
 	public function playerIsInCombat(Player $player) : bool {

--- a/src/RumDaDuMCPE/CombatHUD.php
+++ b/src/RumDaDuMCPE/CombatHUD.php
@@ -1,11 +1,15 @@
 <?php
 
 namespace RumDaDuMCPE;
+use pocketmine\plugin\PluginBase;
+use pocketmine\event\Listener;
+use pocketmine\Player;
 
-class CombatHUD extends \pocketmine\plugin\PluginBase implements \pocketmine\event\Listener {
+class CombatHUD extends PluginBase implements Listener {
 
 	private static $instance;
-
+        public $creativeCheck = false;
+	
 	public function onEnable() {
 		self::$instance = $this;
 		$this->getServer()->getPluginManager()->registerEvents($this, $this);
@@ -17,13 +21,19 @@ class CombatHUD extends \pocketmine\plugin\PluginBase implements \pocketmine\eve
 		return self::$instance;
 	}
 
-	public function playerIsInCombat(\pocketmine\Player $player) : bool {
+	public function playerIsInCombat(Player $player) : bool {
 		$cl = $this->getServer()->getPluginManager()->getPlugin("CombatLogger");
 		if ($cl->isTagged($player)) return true;
 		return false;
 	}
+	public function CreativeCheck(): bool{
+         return $this->creativeCheck;
+	}
+public function setCreativeCheck(bool $creativeCheck){
+$this->creativeCheck = $creativeCheck;
+}
 
-	public function sendHUD(\pocketmine\Player $player) : string {
+	public function sendHUD(Player $player) : string {
 		$cl = $this->getServer()->getPluginManager()->getPlugin("CombatLogger");
 		$timeleft = $cl->getTagDuration($player);
 		return	"§l§cYou are now engaged in combat!\n".

--- a/src/RumDaDuMCPE/CombatHUD.php
+++ b/src/RumDaDuMCPE/CombatHUD.php
@@ -4,11 +4,12 @@ namespace RumDaDuMCPE;
 use pocketmine\plugin\PluginBase;
 use pocketmine\event\Listener;
 use pocketmine\Player;
+use pocketmine\event\player\PlayerJoinEvent;
 
 class CombatHUD extends PluginBase implements Listener {
 
 	private static $instance;
-        public $creativeCheck = false;
+        public $creativeCheck = [];
 	
 	public function onEnable() {
 		self::$instance = $this;
@@ -20,17 +21,21 @@ class CombatHUD extends PluginBase implements Listener {
 	public static function getInstance() {
 		return self::$instance;
 	}
+	public function onJoin(PlayerJoinEvent $event){
+$player = $event->getPlayer();
+		$this->setCreativeCheck(false); //ensures creative checks are false to prevent errors when it isn't recognized.
+	}
 
 	public function playerIsInCombat(Player $player) : bool {
 		$cl = $this->getServer()->getPluginManager()->getPlugin("CombatLogger");
 		if ($cl->isTagged($player)) return true;
 		return false;
 	}
-	public function CreativeCheck(): bool{
-         return $this->creativeCheck;
+	public function hasCreativeCheck(Player $player): bool{
+         return $this->creativeCheck[$player->getName()];
 	}
-public function setCreativeCheck(bool $creativeCheck){
-$this->creativeCheck = $creativeCheck;
+public function setCreativeCheck(Player $player, bool $creativeCheck){
+$this->creativeCheck[$player->getName()] = (bool)$creativeCheck;
 }
 
 	public function sendHUD(Player $player) : string {

--- a/src/RumDaDuMCPE/HUDTask.php
+++ b/src/RumDaDuMCPE/HUDTask.php
@@ -10,7 +10,7 @@ class HUDTask extends Task {
 		$plugin = CombatHUD::getInstance();
 		foreach ($plugin->getServer()->getOnlinePlayers() as $player) {
 			if ($plugin->PlayerisInCombat($player)) {
-				if($player->getAllowFlight() && !$player->isCreative()){
+				if($player->getAllowFlight() && $plugin->CreativeCheck()){
 					$player->setAllowFlight(false);
 					$player->setFlying(false);
 					$player->sendMessage(TextFormat::colorize("&cYou cannot fly whilst in combat. Disabled your flight."));

--- a/src/RumDaDuMCPE/HUDTask.php
+++ b/src/RumDaDuMCPE/HUDTask.php
@@ -3,12 +3,18 @@
 namespace RumDaDuMCPE;
 
 use pocketmine\scheduler\Task;
+use pocketmine\utils\TextFormat;
 
 class HUDTask extends Task {
 	public function onRun (int $currentTick) {
 		$plugin = CombatHUD::getInstance();
 		foreach ($plugin->getServer()->getOnlinePlayers() as $player) {
 			if ($plugin->PlayerisInCombat($player)) {
+				if($player->getAllowFlight() && !$player->isCreative()){
+					$player->setAllowFlight(false);
+					$player->setFlying(false);
+					$player->sendMessage(TextFormat::colorize("&cYou cannot fly whilst in combat. Disabled your flight."));
+				}
 				$player->sendPopup($plugin->sendHUD($player));
 			} else {
 				return;

--- a/src/RumDaDuMCPE/HUDTask.php
+++ b/src/RumDaDuMCPE/HUDTask.php
@@ -4,19 +4,27 @@ namespace RumDaDuMCPE;
 
 use pocketmine\scheduler\Task;
 use pocketmine\utils\TextFormat;
+use pocketmine\Player;
 
 class HUDTask extends Task {
 	public function onRun (int $currentTick) {
 		$plugin = CombatHUD::getInstance();
 		foreach ($plugin->getServer()->getOnlinePlayers() as $player) {
 			if ($plugin->PlayerisInCombat($player)) {
-				if($player->getAllowFlight() && $plugin->CreativeCheck()){
+				if(!$plugin->CreativeCheck($player)){
+$plugin->setCreativeCheck($player, true);
+				}else{
+				if($player->getAllowFlight()){
 					$player->setAllowFlight(false);
 					$player->setFlying(false);
+					$player->setGamemode(Player::SURVIVAL);
 					$player->sendMessage(TextFormat::colorize("&cYou cannot fly whilst in combat. Disabled your flight."));
 				}
 				$player->sendPopup($plugin->sendHUD($player));
 			} else {
+					if($plugin->CreativeCheck($player)){
+					$plugin->setCreativeCheck($player, false);
+					}
 				return;
 			}
 

--- a/src/RumDaDuMCPE/HUDTask.php
+++ b/src/RumDaDuMCPE/HUDTask.php
@@ -11,7 +11,7 @@ class HUDTask extends Task {
 		$plugin = CombatHUD::getInstance();
 		foreach ($plugin->getServer()->getOnlinePlayers() as $player) {
 			if ($plugin->PlayerisInCombat($player)) {
-				if(!$plugin->CreativeCheck($player)){
+				if(!$plugin->hasCreativeCheck($player)){
 $plugin->setCreativeCheck($player, true);
 				}else{
 				if($player->getAllowFlight()){
@@ -22,7 +22,7 @@ $plugin->setCreativeCheck($player, true);
 				}
 				$player->sendPopup($plugin->sendHUD($player));
 			} else {
-					if($plugin->CreativeCheck($player)){
+					if($plugin->hasCreativeCheck($player)){ //checks to ensure creative check doesn't get set to false more than once.
 					$plugin->setCreativeCheck($player, false);
 					}
 				return;

--- a/src/RumDaDuMCPE/HUDTask.php
+++ b/src/RumDaDuMCPE/HUDTask.php
@@ -9,7 +9,11 @@ use pocketmine\Player;
 class HUDTask extends Task {
 	public function onRun (int $currentTick) {
 		$plugin = CombatHUD::getInstance();
+		
 		foreach ($plugin->getServer()->getOnlinePlayers() as $player) {
+		if(!$player->spawned){
+		return;
+		}
 			if ($plugin->PlayerisInCombat($player)) {
 				if(!$plugin->hasCreativeCheck($player)){
 $plugin->setCreativeCheck($player, true);

--- a/src/RumDaDuMCPE/HUDTask.php
+++ b/src/RumDaDuMCPE/HUDTask.php
@@ -18,7 +18,7 @@ $plugin->setCreativeCheck($player, true);
 					$player->setAllowFlight(false);
 					$player->setFlying(false);
 					$player->setGamemode(Player::SURVIVAL);
-					$player->sendMessage(TextFormat::colorize("&cYou cannot fly whilst in combat. Disabled your flight."));
+					$player->sendMessage(TextFormat::colorize(”&cYou cannot fly whilst in combat. Disabled your flight.”));
 				}
 				$player->sendPopup($plugin->sendHUD($player));
 			} else {

--- a/src/RumDaDuMCPE/HUDTask.php
+++ b/src/RumDaDuMCPE/HUDTask.php
@@ -18,7 +18,7 @@ $plugin->setCreativeCheck($player, true);
 					$player->setAllowFlight(false);
 					$player->setFlying(false);
 					$player->setGamemode(Player::SURVIVAL);
-					$player->sendMessage(TextFormat::colorize(”&cYou cannot fly whilst in combat. Disabled your flight.”));
+					$player->sendMessage(TextFormat::colorize("&cYou cannot fly whilst in combat. Disabled your flight."));
 				}
 				$player->sendPopup($plugin->sendHUD($player));
 			} else {

--- a/src/RumDaDuMCPE/HUDTask.php
+++ b/src/RumDaDuMCPE/HUDTask.php
@@ -21,6 +21,7 @@ $plugin->setCreativeCheck($player, true);
 					$player->sendMessage(TextFormat::colorize("&cYou cannot fly whilst in combat. Disabled your flight."));
 				}
 				$player->sendPopup($plugin->sendHUD($player));
+				}
 			} else {
 					if($plugin->hasCreativeCheck($player)){ //checks to ensure creative check doesn't get set to false more than once.
 					$plugin->setCreativeCheck($player, false);


### PR DESCRIPTION
This Pull request pushes out a brand new version, which changes a few aspects of the plugin, to a better state of mind. Though, the plugin’s still the same concept wise, just added a few new features to make the plugin better.

Here are the following updates, made in this newly made v2.0.0 of CombatTimer:

## CombatTimer v2.0.0 CHANGES
- Better formatting for plugin.yml
Implement functional Creative mode checks.
- Rename CreativeCheck() to hasCreativeCheck() for better quality codes. [1 / 2]
- Creative checks no longer depend on the server’s check. It will now require a Player dependency, rather than implementing it to the server, making the plugin non functional. This changes:
1. Parameters for setCreativeCheck(), add’s Player parameter checks.
2. Parameters for hasCreativeCheck(), add’s Player parameter checks.
3. Changed CreativeCheck[] formatted arrays to require player name, instead of being kept false or true without requiring player’s name input.
4. Added onJoin() class event to prevent any future errors with hasCreativeCheck() not being recognised as false or true.
- Reformatted the code to make it look better.
- Fixed Syntax error

This has been untested to work as of yet. But it should work nonetheless. I’ll test this shortly, and get back to you on whether or not this works.